### PR TITLE
ACMS-3639: Fixing deprecations for dataprovider static keyword in php…

### DIFF
--- a/tests/src/functional/Drush/Traits/SiteUriTraitTest.php
+++ b/tests/src/functional/Drush/Traits/SiteUriTraitTest.php
@@ -82,7 +82,7 @@ class SiteUriTraitTest extends FunctionalBaseTest {
    * @return array<string>
    *   List of site uri and site sub directory key.
    */
-  public function siteUriProvider(): array {
+  public static function siteUriProvider(): array {
     return [
       ['http://acquia.com/stage/acquia_cms', 'acquia.com.stage.acquia_cms'],
       ['http://acquia.org:8080/developer/acquia_cms', '8080.acquia.org.developer.acquia_cms'],

--- a/tests/src/unit/Common/ArrayManipulatorTest.php
+++ b/tests/src/unit/Common/ArrayManipulatorTest.php
@@ -117,7 +117,7 @@ class ArrayManipulatorTest extends TestCase {
    * @return array<string>
    *   Returns data provider.
    */
-  public function arrayMergeDataProvider(): array {
+  public static function arrayMergeDataProvider(): array {
     return [
       [
         [['key' => 'one'], ['key' => ['one', 'two']]],
@@ -139,7 +139,7 @@ class ArrayManipulatorTest extends TestCase {
    * @return array<string>
    *   Returns data provider.
    */
-  public function expandFromDotNotatedKeysDataProvider(): array {
+  public static function expandFromDotNotatedKeysDataProvider(): array {
     return [
       [
         ['drush.alias' => "self"],
@@ -158,7 +158,7 @@ class ArrayManipulatorTest extends TestCase {
    * @return array<string>
    *   Returns data provider.
    */
-  public function flattenMultidimensionalArrayDataProvider(): array {
+  public static function flattenMultidimensionalArrayDataProvider(): array {
     return [
       [
         ['drush.alias' => "self"],

--- a/tests/src/unit/Common/StringManipulatorTest.php
+++ b/tests/src/unit/Common/StringManipulatorTest.php
@@ -106,7 +106,7 @@ Expected;
    * @return \string[][]
    *   Returns data provider
    */
-  public function convertStringToMachineSafeDataProvider(): array {
+  public static function convertStringToMachineSafeDataProvider(): array {
     return [
       ["Acquia CMS Common" , "acquia_cms_common"],
       ['Acquia-CMS/Common[1]' , "acquia_cms_common_1"],
@@ -123,7 +123,7 @@ Expected;
    * @return \string[][]
    *   Returns data provider.
    */
-  public function convertStringToPrefixDataProvider(): array {
+  public static function convertStringToPrefixDataProvider(): array {
     return [
       ["Acquia", "A"],
       ["acquia", "A"],


### PR DESCRIPTION
…unit10.

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes ACMS-3639

**Proposed changes**
Static keyword with data providers deprecations fix.
