### PR TITLE
Issue #45: Site:install command fails with Drush 11.

### DIFF
--- a/.github/workflows/drs_ci.yml
+++ b/.github/workflows/drs_ci.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Before Script
         run: ../orca/bin/ci/before_script.sh
       - name: Script
-        run: ../orca/bin/ci/script.sh
+        run: ./tests/scripts/ci/script.sh
       - name: After script
         run: |
           ../orca/bin/ci/after_success.sh

--- a/.github/workflows/drs_ci.yml
+++ b/.github/workflows/drs_ci.yml
@@ -47,7 +47,7 @@ jobs:
          ../orca/bin/ci/after_failure.sh
          ../orca/bin/ci/after_script.sh
  PHPUNIT_TESTS:
-    name: "Run PHPUnit tests on PHP: ${{ matrix.php-version }}"
+    name: "Run PHPUnit tests for CORE: ${{ matrix.orca-job }}, PHP: ${{ matrix.php-version }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -55,8 +55,16 @@ jobs:
           - 8.1
           - 8.2
           - 8.3
+        orca-job:
+          - ISOLATED_TEST_ON_CURRENT
+          - INTEGRATED_TEST_ON_PREVIOUS_MINOR
+        exclude:
+          - orca-job: INTEGRATED_TEST_ON_PREVIOUS_MINOR
+            php-version: 8.3
+          - orca-job: INTEGRATED_TEST_ON_PREVIOUS_MINOR
+            php-version: 8.2
     env:
-      ORCA_JOB: ISOLATED_TEST_ON_CURRENT
+      ORCA_JOB: ${{ matrix.orca-job }}
       CI: TRUE
       ORCA_TEST_BOOTSTRAP_FILE: ${{ github.workspace }}/tests/src/bootstrap.php
     steps:

--- a/tests/packages_alter.yml
+++ b/tests/packages_alter.yml
@@ -1,2 +1,12 @@
 acquia/drupal-recommended-settings:
   type: composer-plugin
+
+drush/drush:
+  is_company_package: false
+  core_matrix:
+    10.1.x:
+      version: 11.x
+      version_dev: 11.x
+    '*':
+      version: 12.x
+      version_dev: 12.x-dev


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes:
Fatal error: Uncaught ArgumentCountError: Too few arguments to function Acquia\Drupal\RecommendedSettings\Drush\Commands\MultisiteDrushCommands::__construct(), 0 passed and exactly 1 expected in /app/vendor/acquia/drupal-recommended-settings/src/Drush/Commands/MultisiteDrushCommands.php on line 34


**Proposed changes**
Use static method call instead of DI

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
