### PR TITLE
ACMS-3759 | Sets hash_salt based on salt.txt only if file is present.

### DIFF
--- a/settings/misc.settings.php
+++ b/settings/misc.settings.php
@@ -22,7 +22,10 @@
  *   $settings['hash_salt'] = file_get_contents('/home/example/salt.txt');
  * @endcode
  */
-$settings['hash_salt'] = file_get_contents(DRUPAL_ROOT . '/../salt.txt');
+$drupal_salt_file_path = DRUPAL_ROOT . '/../salt.txt';
+if (file_exists($drupal_salt_file_path)) {
+  $settings['hash_salt'] = file_get_contents($drupal_salt_file_path);
+}
 
 /**
  * Deployment identifier.


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
When Drupal sites are running on Acquia Cloud and using Acquia’s “require line” as instructed, the included site settings file (the same one that provides database connection instructions) provides an environment-specific value for hash_salt, obviating the need for developers to set this value in project code. However, this functionality is currently nullified by [DRS' misc.settings.php file](https://github.com/acquia/drupal-recommended-settings/blob/develop/settings/misc.settings.php#L25), which invariably overrides this value with the contents of a salt.txt file in the repo root, even if that file is absent or empty. I’d be nice if we could make this override optional to allow developers to leverage this platform feature.

**Proposed changes**
I propose simply checking for the existence of salt.txt before attempting to set its contents as the hash_salt value. This way, developers (like me) who want to use the Acquia-provided salt in Acquia Cloud environments can simply omit this file in our builds on Acquia Cloud.

**Alternatives considered**
Presently, developers can override this functionality in DRS by setting hash_salt after the DRS include in settings.php. However, this does not allow them to automatically leverage the functionality provided by Acquia's settings include.

**Testing steps**
Presently, if salt.txt is absent, and hash_salt is not explicitly set after the DRS include in settings.php, a site running DRS on Acquia Cloud will encounter a fatal RuntimeException preventing Drupal from bootstrapping. The only functional impact of this change is that will resolve this error for apps with this configuration. Functional testing needs, if any, should be minimal. Try loading a Drupal app using DRS on Acquia Cloud with no salt.txt in its repo root and no other value set in the project code for `$settings['hash_salt']`. The change in this PR should allow that to work.
