### PR TITLE
Respect config.yml database credentials if set.

### DIFF
--- a/src/Drush/Commands/SettingsDrushCommands.php
+++ b/src/Drush/Commands/SettingsDrushCommands.php
@@ -46,20 +46,19 @@ class SettingsDrushCommands extends BaseDrushCommands {
     name: 'drush ' . self::SETTINGS_COMMAND . ' --database=mydb --username=myuser --password=mypass --host=127.0.0.1 --port=1234 --uri=site1',
     description: 'Generates the settings.php for site2 passing db credentials.',
   )]
-  public function initSettings(array $options = [
-    'database' => 'drupal',
-    'username' => 'drupal',
-    'password' => 'drupal',
-    'host' => 'localhost',
-    'port' => "3306",
+    public function initSettings(array $options = [
+    'database' => NULL,
+    'username' => NULL,
+    'password' => NULL,
+    'host' => NULL,
+    'port' => NULL,
   ]): int {
-    $db["drupal"]["db"] = [
-      'database' => $options['database'],
-      'username' => $options['username'],
-      'password' => $options['password'],
-      'host' => $options['host'],
-      'port' => $options['port'],
-    ];
+    $db = [];
+    foreach (['database', 'username', 'password', 'host', 'port'] as $key) {
+      if (isset($options[$key])) {
+        $db['drupal']['db'][$key] = $options[$key];
+      }
+    }
     try {
       $site_directory = $this->getSitesSubdirFromUri($this->getConfigValue("docroot"), $this->getConfigValue("drush.uri"));
       $settings = new Settings($this->getConfigValue("docroot"), $site_directory);


### PR DESCRIPTION
**Motivation**
https://github.com/acquia/drupal-recommended-settings/issues/69
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #69

**Proposed changes**
Use the `drs/config.yml` values instead of always the default values.
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
See testing steps in https://github.com/acquia/drupal-recommended-settings/issues/69
<!-- How can we replicate the issue and verify that this PR fixes it? -->
