### PR TITLE
ISSUE-75: Added example on skipping settings.php generation.

### DIFF
--- a/examples/example-drush-command/src/Drush/Commands/ExampleDrushCommands.php
+++ b/examples/example-drush-command/src/Drush/Commands/ExampleDrushCommands.php
@@ -3,10 +3,12 @@
 namespace Example\Drush\Commands;
 
 use Acquia\Drupal\RecommendedSettings\Drush\Commands\MultisiteDrushCommands;
+use Acquia\Drupal\RecommendedSettings\Drush\Commands\SettingsDrushCommands;
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\AnnotatedCommand\Hooks\HookManager;
 use Drush\Attributes as CLI;
 use Drush\Commands\DrushCommands;
+use Robo\ResultData;
 
 /**
  * An example drush command file.
@@ -32,6 +34,19 @@ class ExampleDrushCommands extends DrushCommands {
   public function showSuccessMessage(CommandData $commandData): void {
     $uri = $commandData->input()->getOption("uri");
     $this->io()->info("The settings.php generated successfully for site `" . $uri . "`.");
+  }
+
+  /**
+   * Skip settings.php generation if current environment is CI environment.
+   */
+  #[CLI\Hook(type: HookManager::PRE_COMMAND_HOOK, target: SettingsDrushCommands::SETTINGS_COMMAND)]
+  public function validate(): ?ResultData {
+    $isCI = getenv('CI');
+    if (!$isCI) {
+      return NULL;
+    }
+    $this->io()->info("Skip settings.php generation for CI environment.");
+    return new ResultData(ResultData::EXITCODE_OK);
   }
 
 }


### PR DESCRIPTION
**Motivation**
Added an example which developers can follow to skip settings.php generation for certain use cases.

**Proposed changes**
Example file added showing on how to skip settings.php generation.

**Alternatives considered**
The Alternative thought be provide the similar way that BLT provides, but want to keep it simple and extensible, so ideal approach could be giving flexibility to developers, where they can create their own library/drush command and add their own checks to skip the settings.php generation logic.

**Testing steps**
1. Include the example drush command in project.
2. Set the environment variable i.e CI=true.
3. Run the command `drush drs:init:settings` and you'll notice generation of settings.php is skipped.. 
