### PR TITLE
ACMS-4134: Add settings file for mysql backport module if it exists

### DIFF
--- a/settings/acquia-recommended.settings.php
+++ b/settings/acquia-recommended.settings.php
@@ -76,6 +76,11 @@ if ($ip) {
 
 $settings_files = [];
 
+// Add settings file for mysql57 backport module if present.
+if (file_exists(DRUPAL_ROOT . '/modules/contrib/mysql57/settings.inc')) {
+  require DRUPAL_ROOT . '/modules/contrib/mysql57/settings.inc';
+}
+
 /**
  * Site path.
  *

--- a/settings/acquia-recommended.settings.php
+++ b/settings/acquia-recommended.settings.php
@@ -139,3 +139,8 @@ foreach ($settings_files as $settings_file) {
     require $settings_file;
   }
 }
+
+// Add settings file for mysql57 backport module if present.
+if (file_exists(DRUPAL_ROOT . '/modules/contrib/mysql57/settings.inc')) {
+  require DRUPAL_ROOT . '/modules/contrib/mysql57/settings.inc';
+}


### PR DESCRIPTION
**Motivation**
Out of the box, applications using acquia/drupal-recommended-settings fail to bootstrap in Acquia environments that aren't running MySQL 8 (e.g. Cloud, IDEs). This is because the include provided by the MySQL 5.7 was removed in e14fb51ea91acf283bb3c5af312e34fe655caf80. This PR adds it back.

**Proposed changes**
Add the include for the MySQL 5.7 module back into the default recommended settings file. Also move the include to the very end of the file because the database connection is overwritten on line 139 in certain environments and the settings from include are lost if it's included earlier.

