### PR TITLE
ACMS-4480: Include settings for MySQL Compatibility.

### DIFF
--- a/settings/acquia-recommended.settings.php
+++ b/settings/acquia-recommended.settings.php
@@ -84,9 +84,17 @@ $settings_files = [];
  */
 // phpcs:ignore
 $site_name = EnvironmentDetector::getSiteName($site_path);
+
 // Acquia Cloud settings.
 if (EnvironmentDetector::isAhEnv()) {
   try {
+    // Acquia cloud expects mysql57 settings file
+    // to be included before any settings.
+    // Though Cloud IDE expect it to be included after db settings.
+    // @todo: Remove this line once acquia platform start supporting myslql 8.0
+    if(!EnvironmentDetector::isAhIdeEnv()) {
+      $settings_files[] = __DIR__ . "/mysql57.settings.php";
+    }
     if (!EnvironmentDetector::isAcsfEnv()) {
       $settings_files[] = FilePaths::ahSettingsFile(EnvironmentDetector::getAhGroup(), $site_name);
     }
@@ -101,7 +109,6 @@ if (EnvironmentDetector::isAhEnv()) {
   $settings_files[] = EnvironmentDetector::getAhFilesRoot() . '/secrets.settings.php';
   $settings_files[] = EnvironmentDetector::getAhFilesRoot() . "/$site_name/secrets.settings.php";
 }
-
 // Default global settings.
 $acquia_settings_files = [
   'cache',
@@ -109,8 +116,12 @@ $acquia_settings_files = [
   'logging',
   'filesystem',
   'misc',
-  'mysql57',
 ];
+// Cloud IDE expect mysql57 driver to be included after db settings.
+if(EnvironmentDetector::isAhIdeEnv()) {
+  $acquia_settings_files[] = 'mysql57';
+}
+
 foreach ($acquia_settings_files as $recommended_settings_file) {
   $settings_files[] = __DIR__ . "/$recommended_settings_file.settings.php";
 }

--- a/settings/acquia-recommended.settings.php
+++ b/settings/acquia-recommended.settings.php
@@ -85,18 +85,26 @@ $settings_files = [];
 // phpcs:ignore
 $site_name = EnvironmentDetector::getSiteName($site_path);
 
-// Acquia Cloud settings.
+// Acquia platform settings includes a require line that
+// opens database connection, hence the mysql57 settings
+// file should be added before platform require line.
+// @see: https://www.drupal.org/project/mysql57
+// @todo: Remove this line once acquia platform start supporting mysql 8.0
+if(!EnvironmentDetector::isAhIdeEnv()) {
+  $settings_files[] = __DIR__ . "/mysql57.settings.php";
+}
+
+// Acquia Cloud settings
 if (EnvironmentDetector::isAhEnv()) {
   try {
-    // Acquia cloud expects mysql57 settings file
-    // to be included before any settings.
-    // Though Cloud IDE expect it to be included after db settings.
-    // @todo: Remove this line once acquia platform start supporting myslql 8.0
-    if(!EnvironmentDetector::isAhIdeEnv()) {
-      $settings_files[] = __DIR__ . "/mysql57.settings.php";
-    }
     if (!EnvironmentDetector::isAcsfEnv()) {
       $settings_files[] = FilePaths::ahSettingsFile(EnvironmentDetector::getAhGroup(), $site_name);
+    }
+    // Acquia Cloud IDE settings have $databases variable defined hence
+    // the mysql57 setting file should be added after platform require line.
+    // @todo: Remove this line once acquia platform start supporting mysql 8.0
+    if(EnvironmentDetector::isAhIdeEnv()) {
+      $settings_files[] = __DIR__ . "/mysql57.settings.php";
     }
   }
   catch (SettingsException $e) {
@@ -117,11 +125,6 @@ $acquia_settings_files = [
   'filesystem',
   'misc',
 ];
-// Cloud IDE expect mysql57 driver to be included after db settings.
-if(EnvironmentDetector::isAhIdeEnv()) {
-  $acquia_settings_files[] = 'mysql57';
-}
-
 foreach ($acquia_settings_files as $recommended_settings_file) {
   $settings_files[] = __DIR__ . "/$recommended_settings_file.settings.php";
 }

--- a/settings/acquia-recommended.settings.php
+++ b/settings/acquia-recommended.settings.php
@@ -109,6 +109,7 @@ $acquia_settings_files = [
   'logging',
   'filesystem',
   'misc',
+  'mysql57',
 ];
 foreach ($acquia_settings_files as $recommended_settings_file) {
   $settings_files[] = __DIR__ . "/$recommended_settings_file.settings.php";

--- a/settings/acquia-recommended.settings.php
+++ b/settings/acquia-recommended.settings.php
@@ -85,18 +85,17 @@ $settings_files = [];
 // phpcs:ignore
 $site_name = EnvironmentDetector::getSiteName($site_path);
 
-// Acquia platform settings (and local / CI) includes a require line
-// that opens database connection, hence the mysql57 settings
-// file should be added before platform require line.
-// @see: https://www.drupal.org/project/mysql57
-// @todo: Remove this line once acquia platform start supporting mysql 8.0
-if(!EnvironmentDetector::isAhIdeEnv()) {
-  $settings_files[] = __DIR__ . "/mysql57.settings.php";
-}
-
-// Acquia Cloud settings
+// Acquia Cloud settings.
 if (EnvironmentDetector::isAhEnv()) {
   try {
+    // Acquia platform settings includes a require line
+    // that opens database connection, hence the mysql57 settings
+    // file should be added before platform require line.
+    // @see: https://www.drupal.org/project/mysql57
+    // @todo: Remove this line once acquia platform start supporting mysql 8.0
+    if(!EnvironmentDetector::isAhIdeEnv()) {
+      $settings_files[] = __DIR__ . "/mysql57.settings.php";
+    }
     if (!EnvironmentDetector::isAcsfEnv()) {
       $settings_files[] = FilePaths::ahSettingsFile(EnvironmentDetector::getAhGroup(), $site_name);
     }

--- a/settings/acquia-recommended.settings.php
+++ b/settings/acquia-recommended.settings.php
@@ -85,8 +85,8 @@ $settings_files = [];
 // phpcs:ignore
 $site_name = EnvironmentDetector::getSiteName($site_path);
 
-// Acquia platform settings includes a require line that
-// opens database connection, hence the mysql57 settings
+// Acquia platform settings (and local / CI) includes a require line
+// that opens database connection, hence the mysql57 settings
 // file should be added before platform require line.
 // @see: https://www.drupal.org/project/mysql57
 // @todo: Remove this line once acquia platform start supporting mysql 8.0

--- a/settings/mysql57.settings.php
+++ b/settings/mysql57.settings.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * @file
+ * Settings file for mysql57 backport module if present.
+ */
+if (file_exists(DRUPAL_ROOT . '/modules/contrib/mysql57/settings.inc')) {
+  require DRUPAL_ROOT . '/modules/contrib/mysql57/settings.inc';
+}


### PR DESCRIPTION
We've encountered a compatibility issue with Drupal 11 installations on our Cloud IDE due to the use of MySQL 5.7 instead of MySQL 8. To streamline the installation process and eliminate the need for manual configuration by users, we need to make an update to the acquia/drupal-recommended-settings plugin.

**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #[ACMS-4480](https://acquia.atlassian.net/browse/ACMS-4480)

**Proposed changes**
Include mysql57 related settings to support site install on Acquia Cloud server including Cloud IDE.

**Alternatives considered**
NA

**Testing steps**
- Spin up cloud IDE
- Create new project by running command `acli new /home/ide/project`
- Then select project as  `acquia/drupal-recommended-project`
- Add this PR changes by running command `composer require acquia/drupal-recommended-settings:dev-ACMS-4480`
- Site install using drush `./vendor/bin/drush si -y`
- Make sure you don't see any issue during install specially related to mysql.