### PR TITLE
ONR-30: Updated the 'file_private_path' to be outside of docroot.

### DIFF
--- a/settings/ci.settings.php
+++ b/settings/ci.settings.php
@@ -5,10 +5,12 @@
  * Common settings for CI envs.
  */
 
+use Acquia\Drupal\RecommendedSettings\Helpers\EnvironmentDetector;
+
 $config['system.logging']['error_level'] = 'verbose';
 
-$dir = dirname(DRUPAL_ROOT);
-$settings['file_private_path'] = $dir . '/files-private';
+$settings['file_private_path'] = EnvironmentDetector::getRepoRoot() . '/files-private/' . EnvironmentDetector::getSiteName($site_path);
+
 $settings['trusted_host_patterns'] = [
   '^.+$',
 ];

--- a/tests/src/Functional/Config/ConfigInitializerTest.php
+++ b/tests/src/Functional/Config/ConfigInitializerTest.php
@@ -71,6 +71,10 @@ class ConfigInitializerTest extends FunctionalTestBase {
   /**
    * Tests determineEnvironment() method.
    *
+   * Below DocBlock added for legacy fallback for PHPUnit < 10.
+   *
+   * @runInSeparateProcess
+   *
    * @throws \ReflectionException
    */
   #[RunInSeparateProcess]
@@ -97,6 +101,10 @@ class ConfigInitializerTest extends FunctionalTestBase {
 
   /**
    * Tests the initialize() method.
+   *
+   * Below DocBlock added for legacy fallback for PHPUnit < 10.
+   *
+   * @runInSeparateProcess
    */
   #[RunInSeparateProcess]
   public function testInitialize(): void {
@@ -141,6 +149,10 @@ class ConfigInitializerTest extends FunctionalTestBase {
 
   /**
    * Tests the loadAllConfig() method.
+   *
+   * Below DocBlock added for legacy fallback for PHPUnit < 10.
+   *
+   * @runInSeparateProcess
    */
   #[RunInSeparateProcess]
   public function testLoadAllConfig(): void {

--- a/tests/src/Functional/Config/ConfigInitializerTest.php
+++ b/tests/src/Functional/Config/ConfigInitializerTest.php
@@ -5,6 +5,7 @@ namespace Acquia\Drupal\RecommendedSettings\Tests\Functional\Config;
 use Acquia\Drupal\RecommendedSettings\Config\ConfigInitializer;
 use Acquia\Drupal\RecommendedSettings\Config\DefaultDrushConfig;
 use Acquia\Drupal\RecommendedSettings\Tests\FunctionalTestBase;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\StringInput;
@@ -72,6 +73,7 @@ class ConfigInitializerTest extends FunctionalTestBase {
    *
    * @throws \ReflectionException
    */
+  #[RunInSeparateProcess]
   public function testDetermineEnvironment(): void {
     putenv("CI=");
     $config = new DefaultDrushConfig();
@@ -96,6 +98,7 @@ class ConfigInitializerTest extends FunctionalTestBase {
   /**
    * Tests the initialize() method.
    */
+  #[RunInSeparateProcess]
   public function testInitialize(): void {
     putenv("CI=");
     $config = new DefaultDrushConfig();
@@ -139,6 +142,7 @@ class ConfigInitializerTest extends FunctionalTestBase {
   /**
    * Tests the loadAllConfig() method.
    */
+  #[RunInSeparateProcess]
   public function testLoadAllConfig(): void {
     putenv("CI=");
     $config = new DefaultDrushConfig();

--- a/tests/src/Functional/Helpers/EnvironmentDetectorTest.php
+++ b/tests/src/Functional/Helpers/EnvironmentDetectorTest.php
@@ -95,7 +95,7 @@ class EnvironmentDetectorTest extends FunctionalTestBase {
     putenv("GITLAB_CI_TOKEN=");
     putenv("CI=");
     $this->assertFalse(EnvironmentDetector::isCiEnv());
-    putenv("CI=true");
+    putenv("CI=TRUE");
     $this->assertTrue(EnvironmentDetector::isCiEnv());
   }
 

--- a/tests/src/Functional/Helpers/EnvironmentDetectorTest.php
+++ b/tests/src/Functional/Helpers/EnvironmentDetectorTest.php
@@ -10,6 +10,7 @@ use Composer\Composer;
 use Composer\Config;
 use Composer\IO\IOInterface;
 use Composer\Package\RootPackage;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
  * Functional test for the EnvironmentDetectorTest class.
@@ -75,6 +76,7 @@ class EnvironmentDetectorTest extends FunctionalTestBase {
    *
    * @throws \ReflectionException
    */
+  #[RunInSeparateProcess]
   public function testGetCiEnv(): void {
 
     putenv("PIPELINE_ENV=TRUE");
@@ -87,8 +89,9 @@ class EnvironmentDetectorTest extends FunctionalTestBase {
 
     putenv("PIPELINE_ENV=");
     putenv("GITLAB_CI_TOKEN=");
+    putenv("CI=");
     $this->assertFalse(EnvironmentDetector::isCiEnv());
-    putenv("CI=TRUE");
+    putenv("CI=true");
     $this->assertTrue(EnvironmentDetector::isCiEnv());
   }
 
@@ -97,6 +100,7 @@ class EnvironmentDetectorTest extends FunctionalTestBase {
    *
    * @throws \ReflectionException
    */
+  #[RunInSeparateProcess]
   public function testGetCiSettingsFile(): void {
     putenv("PIPELINE_ENV=TRUE");
     $this->assertStringEndsWith('/acquia/drupal-recommended-settings/settings/pipelines.settings.php', EnvironmentDetector::getCiSettingsFile());
@@ -107,6 +111,7 @@ class EnvironmentDetectorTest extends FunctionalTestBase {
    *
    * @throws \ReflectionException
    */
+  #[RunInSeparateProcess]
   public function testMultipleEnv(): void {
     putenv("PIPELINE_ENV=");
     putenv("CI=");
@@ -130,6 +135,7 @@ class EnvironmentDetectorTest extends FunctionalTestBase {
   /**
    * Test EnvironmentDetector::isAcsfInited().
    */
+  #[RunInSeparateProcess]
   public function testIsAcsfInited(): void {
     // Generate folder/files for ACSF.
     $drsFileSystem = new DrsFilesystem();
@@ -160,6 +166,7 @@ class EnvironmentDetectorTest extends FunctionalTestBase {
    *
    * @throws \ReflectionException
    */
+  #[RunInSeparateProcess]
   public function testGetSiteName(): void {
     $sitePath = "sites/site1";
     $this->assertSame('site1', EnvironmentDetector::getSiteName($sitePath));
@@ -189,6 +196,7 @@ class EnvironmentDetectorTest extends FunctionalTestBase {
   /**
    * Test EnvironmentDetector::getSiteName().
    */
+  #[RunInSeparateProcess]
   public function testGetSiteNameForLocalAcsf(): void {
     if (getenv("ORCA_FIXTURE_DIR")) {
       // Due to some reasons, we've to manually copy fixture directories to
@@ -230,6 +238,7 @@ class EnvironmentDetectorTest extends FunctionalTestBase {
    *
    * @throws \ReflectionException
    */
+  #[RunInSeparateProcess]
   public function testGetEnvironments(): void {
     $ci_updated = FALSE;
     if (getenv("CI")) {

--- a/tests/src/Functional/Helpers/EnvironmentDetectorTest.php
+++ b/tests/src/Functional/Helpers/EnvironmentDetectorTest.php
@@ -74,6 +74,10 @@ class EnvironmentDetectorTest extends FunctionalTestBase {
   /**
    * Tests EnvironmentDetector::getCiEnv().
    *
+   * Below DocBlock added for legacy fallback for PHPUnit < 10.
+   *
+   * @runInSeparateProcess
+   *
    * @throws \ReflectionException
    */
   #[RunInSeparateProcess]
@@ -98,6 +102,10 @@ class EnvironmentDetectorTest extends FunctionalTestBase {
   /**
    * Verify Ci settings file suggestion exists.
    *
+   * Below DocBlock added for legacy fallback for PHPUnit < 10.
+   *
+   * @runInSeparateProcess
+   *
    * @throws \ReflectionException
    */
   #[RunInSeparateProcess]
@@ -108,6 +116,10 @@ class EnvironmentDetectorTest extends FunctionalTestBase {
 
   /**
    * Verify multiple environment.
+   *
+   * Below DocBlock added for legacy fallback for PHPUnit < 10.
+   *
+   * @runInSeparateProcess
    *
    * @throws \ReflectionException
    */
@@ -134,6 +146,10 @@ class EnvironmentDetectorTest extends FunctionalTestBase {
 
   /**
    * Test EnvironmentDetector::isAcsfInited().
+   *
+   * Below DocBlock added for legacy fallback for PHPUnit < 10.
+   *
+   * @runInSeparateProcess
    */
   #[RunInSeparateProcess]
   public function testIsAcsfInited(): void {
@@ -163,6 +179,10 @@ class EnvironmentDetectorTest extends FunctionalTestBase {
 
   /**
    * Test EnvironmentDetector::getSiteName().
+   *
+   * Below DocBlock added for legacy fallback for PHPUnit < 10.
+   *
+   * @runInSeparateProcess
    *
    * @throws \ReflectionException
    */
@@ -195,6 +215,10 @@ class EnvironmentDetectorTest extends FunctionalTestBase {
 
   /**
    * Test EnvironmentDetector::getSiteName().
+   *
+   * Below DocBlock added for legacy fallback for PHPUnit < 10.
+   *
+   * @runInSeparateProcess
    */
   #[RunInSeparateProcess]
   public function testGetSiteNameForLocalAcsf(): void {
@@ -235,6 +259,10 @@ class EnvironmentDetectorTest extends FunctionalTestBase {
 
   /**
    * Test EnvironmentDetector::getEnvironments().
+   *
+   * Below DocBlock added for legacy fallback for PHPUnit < 10.
+   *
+   * @runInSeparateProcess
    *
    * @throws \ReflectionException
    */

--- a/tests/src/Functional/SettingsFileTest.php
+++ b/tests/src/Functional/SettingsFileTest.php
@@ -38,8 +38,8 @@ class SettingsFileTest extends FunctionalTestBase {
   public function testAcquiaRecommendedSettingsFile(): void {
     // Drupal expects these variables to be predeclared in the scope.
     $site_path = 'default';
+    $app_root = $this->projectRoot;
     $settings = [];
-    dump(file_get_contents(DRUPAL_ROOT . "/sites/default/settings.php"));
     include_once DRUPAL_ROOT . '/sites/default/settings.php';
     $this->assertNotEmpty($settings);
     $this->assertArrayHasKey('config_sync_directory', $settings);
@@ -50,7 +50,7 @@ class SettingsFileTest extends FunctionalTestBase {
     $this->assertSame("../config/$site_path", $settings['config_sync_directory']);
     $this->assertSame("../sitestudio/$site_path", $settings['site_studio_sync']);
     $this->assertSame("sites/$site_path/files", $settings['file_public_path']);
-    $this->assertSame($this->projectRoot . "/files-private/$site_path", $settings['file_private_path']);
+    $this->assertSame($app_root . "/files-private/$site_path", $settings['file_private_path']);
     $this->assertNotEmpty($settings['hash_salt']);
   }
 
@@ -67,6 +67,7 @@ class SettingsFileTest extends FunctionalTestBase {
    */
   private function createFixture(): void {
     if (defined('DRUPAL_ROOT')) {
+      $this->projectRoot = dirname(DRUPAL_ROOT);
       return;
     }
     $this->projectRoot = sys_get_temp_dir() . DIRECTORY_SEPARATOR . RandomString::string(5, TRUE, NULL, 'abcdefghijklmnopqrstuvwxyz');

--- a/tests/src/Functional/SettingsFileTest.php
+++ b/tests/src/Functional/SettingsFileTest.php
@@ -3,6 +3,7 @@
 namespace Acquia\Drupal\RecommendedSettings\Tests\Functional;
 
 use Acquia\Drupal\RecommendedSettings\Common\RandomString;
+use Acquia\Drupal\RecommendedSettings\Helpers\EnvironmentDetector;
 use Acquia\Drupal\RecommendedSettings\Settings;
 use Acquia\Drupal\RecommendedSettings\Tests\FunctionalTestBase;
 use Acquia\Drupal\RecommendedSettings\Tests\Mock\Drupal;
@@ -59,7 +60,7 @@ class SettingsFileTest extends FunctionalTestBase {
    * {@inheritdoc}
    */
   public function tearDown(): void {
-    if (!getenv("ORCA_FIXTURE_DIR")) {
+    if (EnvironmentDetector::isLocalEnv()) {
       $this->fileSystem->remove($this->projectRoot);
     }
     parent::tearDown();
@@ -69,12 +70,7 @@ class SettingsFileTest extends FunctionalTestBase {
    * Builds a temporary Drupal fixture for tests.
    */
   private function createFixtureForLocal(): void {
-    if (getenv("ORCA_FIXTURE_DIR")) {
-      // As some tests are updating CI environment, due to this the
-      // EnvironmentDetector::isCiEnv() is returning false here.
-      // Hence, we are using 'ORCA_FIXTURE_DIR' environment check here.
-      // @todo Revisit and fix those tests to not update CI environment and
-      //   update this check.
+    if (EnvironmentDetector::isCiEnv()) {
       $this->assertTrue(defined(DRUPAL_ROOT));
       $this->projectRoot = dirname(DRUPAL_ROOT);
       return;

--- a/tests/src/Functional/SettingsFileTest.php
+++ b/tests/src/Functional/SettingsFileTest.php
@@ -3,6 +3,7 @@
 namespace Acquia\Drupal\RecommendedSettings\Tests\Functional;
 
 use Acquia\Drupal\RecommendedSettings\Common\RandomString;
+use Acquia\Drupal\RecommendedSettings\Helpers\EnvironmentDetector;
 use Acquia\Drupal\RecommendedSettings\Settings;
 use Acquia\Drupal\RecommendedSettings\Tests\FunctionalTestBase;
 use Acquia\Drupal\RecommendedSettings\Tests\Mock\Drupal;
@@ -29,45 +30,48 @@ class SettingsFileTest extends FunctionalTestBase {
   public function setUp(): void {
     parent::setUp();
     $this->fileSystem = new Filesystem();
-    $this->createFixture();
+    dump(EnvironmentDetector::isCiEnv());
+    //$this->createFixtureForLocal();
   }
 
   /**
    * Verifies settings.php generates expected values.
    */
   public function testAcquiaRecommendedSettingsFile(): void {
-    // Drupal expects these variables to be predeclared in the scope.
+      return;
     $site_path = 'default';
     $settings = [];
     $this->assertTrue(TRUE);
-    return;
-//    include_once "{$this->projectRoot}/vendor/acquia/drupal-recommended-settings/settings/acquia-recommended.settings.php";
-//    $this->assertNotEmpty($settings);
-//    $this->assertArrayHasKey('config_sync_directory', $settings);
-//    $this->assertArrayHasKey('site_studio_sync', $settings);
-//    $this->assertArrayHasKey('file_public_path', $settings);
-//    $this->assertArrayHasKey('hash_salt', $settings);
-//    $this->assertArrayHasKey('file_private_path', $settings);
-//    $this->assertSame("../config/$site_path", $settings['config_sync_directory']);
-//    $this->assertSame("../sitestudio/$site_path", $settings['site_studio_sync']);
-//    $this->assertSame("sites/$site_path/files", $settings['file_public_path']);
-//    $this->assertSame($this->projectRoot . "/files-private/$site_path", $settings['file_private_path']);
-//    $this->assertNotEmpty($settings['hash_salt']);
+    include_once "{$this->projectRoot}/vendor/acquia/drupal-recommended-settings/settings/acquia-recommended.settings.php";
+    $this->assertNotEmpty($settings);
+    $this->assertArrayHasKey('config_sync_directory', $settings);
+    $this->assertArrayHasKey('site_studio_sync', $settings);
+    $this->assertArrayHasKey('file_public_path', $settings);
+    $this->assertArrayHasKey('hash_salt', $settings);
+    $this->assertArrayHasKey('file_private_path', $settings);
+    $this->assertSame("../config/$site_path", $settings['config_sync_directory']);
+    $this->assertSame("../sitestudio/$site_path", $settings['site_studio_sync']);
+    $this->assertSame("sites/$site_path/files", $settings['file_public_path']);
+    $this->assertSame($this->projectRoot . "/files-private/$site_path", $settings['file_private_path']);
+    $this->assertNotEmpty($settings['hash_salt']);
   }
 
   /**
    * {@inheritdoc}
    */
   public function tearDown(): void {
-    $this->fileSystem->remove($this->projectRoot);
+//    if (EnvironmentDetector::isLocalEnv()) {
+//      $this->fileSystem->remove($this->projectRoot);
+//    }
     parent::tearDown();
   }
 
   /**
    * Builds a temporary Drupal fixture for tests.
    */
-  private function createFixture(): void {
-    if (defined('DRUPAL_ROOT')) {
+  private function createFixtureForLocal(): void {
+    if (!EnvironmentDetector::isLocalEnv()) {
+      $this->assertTrue(defined(DRUPAL_ROOT));
       $this->projectRoot = dirname(DRUPAL_ROOT);
       return;
     }

--- a/tests/src/Functional/SettingsFileTest.php
+++ b/tests/src/Functional/SettingsFileTest.php
@@ -3,10 +3,10 @@
 namespace Acquia\Drupal\RecommendedSettings\Tests\Functional;
 
 use Acquia\Drupal\RecommendedSettings\Common\RandomString;
-use Acquia\Drupal\RecommendedSettings\Helpers\EnvironmentDetector;
 use Acquia\Drupal\RecommendedSettings\Settings;
 use Acquia\Drupal\RecommendedSettings\Tests\FunctionalTestBase;
 use Acquia\Drupal\RecommendedSettings\Tests\Mock\Drupal;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -30,15 +30,14 @@ class SettingsFileTest extends FunctionalTestBase {
   public function setUp(): void {
     parent::setUp();
     $this->fileSystem = new Filesystem();
-    dump(EnvironmentDetector::isCiEnv());
-    //$this->createFixtureForLocal();
+    $this->createFixtureForLocal();
   }
 
   /**
    * Verifies settings.php generates expected values.
    */
+  #[RunInSeparateProcess]
   public function testAcquiaRecommendedSettingsFile(): void {
-      return;
     $site_path = 'default';
     $settings = [];
     $this->assertTrue(TRUE);
@@ -60,9 +59,9 @@ class SettingsFileTest extends FunctionalTestBase {
    * {@inheritdoc}
    */
   public function tearDown(): void {
-//    if (EnvironmentDetector::isLocalEnv()) {
-//      $this->fileSystem->remove($this->projectRoot);
-//    }
+    if (!getenv("ORCA_FIXTURE_DIR")) {
+      $this->fileSystem->remove($this->projectRoot);
+    }
     parent::tearDown();
   }
 
@@ -70,7 +69,12 @@ class SettingsFileTest extends FunctionalTestBase {
    * Builds a temporary Drupal fixture for tests.
    */
   private function createFixtureForLocal(): void {
-    if (!EnvironmentDetector::isLocalEnv()) {
+    if (getenv("ORCA_FIXTURE_DIR")) {
+      // As some tests are updating CI environment, due to this the
+      // EnvironmentDetector::isCiEnv() is returning false here.
+      // Hence, we are using 'ORCA_FIXTURE_DIR' environment check here.
+      // @todo Revisit and fix those tests to not update CI environment and
+      //   update this check.
       $this->assertTrue(defined(DRUPAL_ROOT));
       $this->projectRoot = dirname(DRUPAL_ROOT);
       return;

--- a/tests/src/Functional/SettingsFileTest.php
+++ b/tests/src/Functional/SettingsFileTest.php
@@ -70,8 +70,7 @@ class SettingsFileTest extends FunctionalTestBase {
    * Builds a temporary Drupal fixture for tests.
    */
   private function createFixtureForLocal(): void {
-    if (EnvironmentDetector::isCiEnv()) {
-      $this->assertTrue(defined(DRUPAL_ROOT));
+    if (defined('DRUPAL_ROOT')) {
       $this->projectRoot = dirname(DRUPAL_ROOT);
       return;
     }

--- a/tests/src/Functional/SettingsFileTest.php
+++ b/tests/src/Functional/SettingsFileTest.php
@@ -39,6 +39,7 @@ class SettingsFileTest extends FunctionalTestBase {
     // Drupal expects these variables to be predeclared in the scope.
     $site_path = 'default';
     $settings = [];
+    dump(file_get_contents(DRUPAL_ROOT . "/sites/default/settings.php"));
     include_once DRUPAL_ROOT . '/sites/default/settings.php';
     $this->assertNotEmpty($settings);
     $this->assertArrayHasKey('config_sync_directory', $settings);

--- a/tests/src/Functional/SettingsFileTest.php
+++ b/tests/src/Functional/SettingsFileTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Acquia\Drupal\RecommendedSettings\Tests\Functional;
+
+use Acquia\Drupal\RecommendedSettings\Common\RandomString;
+use Acquia\Drupal\RecommendedSettings\Settings;
+use Acquia\Drupal\RecommendedSettings\Tests\FunctionalTestBase;
+use Acquia\Drupal\RecommendedSettings\Tests\Mock\Drupal;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Functional test for the acquia-recommended.settings.php.
+ */
+class SettingsFileTest extends FunctionalTestBase {
+
+  /**
+   * The path to drupal project root.
+   */
+  protected string $projectRoot;
+
+  /**
+   * The symfony file-system helper.
+   */
+  protected Filesystem $fileSystem;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+    $this->fileSystem = new Filesystem();
+    $this->createFixture();
+  }
+
+  /**
+   * Verifies settings.php generates expected values.
+   */
+  public function testAcquiaRecommendedSettingsFile(): void {
+    // Drupal expects these variables to be predeclared in the scope.
+    $site_path = 'default';
+    $settings = [];
+    include_once DRUPAL_ROOT . '/sites/default/settings.php';
+    $this->assertNotEmpty($settings);
+    $this->assertArrayHasKey('config_sync_directory', $settings);
+    $this->assertArrayHasKey('site_studio_sync', $settings);
+    $this->assertArrayHasKey('file_public_path', $settings);
+    $this->assertArrayHasKey('hash_salt', $settings);
+    $this->assertArrayHasKey('file_private_path', $settings);
+    $this->assertSame("../config/$site_path", $settings['config_sync_directory']);
+    $this->assertSame("../sitestudio/$site_path", $settings['site_studio_sync']);
+    $this->assertSame("sites/$site_path/files", $settings['file_public_path']);
+    $this->assertSame($this->projectRoot . "/files-private/$site_path", $settings['file_private_path']);
+    $this->assertNotEmpty($settings['hash_salt']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function tearDown(): void {
+    $this->fileSystem->remove($this->projectRoot);
+    parent::tearDown();
+  }
+
+  /**
+   * Builds a temporary Drupal fixture for tests.
+   */
+  private function createFixture(): void {
+    if (defined('DRUPAL_ROOT')) {
+      return;
+    }
+    $this->projectRoot = sys_get_temp_dir() . DIRECTORY_SEPARATOR . RandomString::string(5, TRUE, NULL, 'abcdefghijklmnopqrstuvwxyz');
+    define('DRUPAL_ROOT', $this->projectRoot . '/docroot');
+    $this->fileSystem->mirror($this->getProjectRoot(), $this->projectRoot);
+    $destination_plugin_path = $this->projectRoot . "/vendor/acquia/drupal-recommended-settings";
+    $is_success = mkdir($destination_plugin_path, 0755, TRUE);
+    $this->assertTrue($is_success);
+    $this->fileSystem->mirror(Settings::getPluginPath() . '/settings', $destination_plugin_path . "/settings");
+    class_alias(Drupal::class, 'Drupal');
+    $this->fileSystem->dumpFile("{$this->projectRoot}/salt.txt", RandomString::string(55));
+    $this->fileSystem->dumpFile(DRUPAL_ROOT . "/sites/default/default.settings.php", "<?php\n");
+    $settings = new Settings(DRUPAL_ROOT, "default");
+    $settings->generate([
+      'drupal' => [
+        'db' => [
+          'database' => 'drs',
+          'username' => 'drupal',
+          'password' => 'drupal',
+          'host' => 'localhost',
+          'port' => '3306',
+        ],
+      ],
+    ]);
+  }
+
+}

--- a/tests/src/Functional/SettingsFileTest.php
+++ b/tests/src/Functional/SettingsFileTest.php
@@ -36,6 +36,10 @@ class SettingsFileTest extends FunctionalTestBase {
 
   /**
    * Verifies settings.php generates expected values.
+   *
+   * Below DocBlock added for legacy fallback for PHPUnit < 10.
+   *
+   * @runInSeparateProcess
    */
   #[RunInSeparateProcess]
   public function testAcquiaRecommendedSettingsFile(): void {

--- a/tests/src/Functional/SettingsFileTest.php
+++ b/tests/src/Functional/SettingsFileTest.php
@@ -38,20 +38,21 @@ class SettingsFileTest extends FunctionalTestBase {
   public function testAcquiaRecommendedSettingsFile(): void {
     // Drupal expects these variables to be predeclared in the scope.
     $site_path = 'default';
-    $app_root = $this->projectRoot;
     $settings = [];
-    include_once DRUPAL_ROOT . '/sites/default/settings.php';
-    $this->assertNotEmpty($settings);
-    $this->assertArrayHasKey('config_sync_directory', $settings);
-    $this->assertArrayHasKey('site_studio_sync', $settings);
-    $this->assertArrayHasKey('file_public_path', $settings);
-    $this->assertArrayHasKey('hash_salt', $settings);
-    $this->assertArrayHasKey('file_private_path', $settings);
-    $this->assertSame("../config/$site_path", $settings['config_sync_directory']);
-    $this->assertSame("../sitestudio/$site_path", $settings['site_studio_sync']);
-    $this->assertSame("sites/$site_path/files", $settings['file_public_path']);
-    $this->assertSame($app_root . "/files-private/$site_path", $settings['file_private_path']);
-    $this->assertNotEmpty($settings['hash_salt']);
+    $this->assertTrue(TRUE);
+    return;
+//    include_once "{$this->projectRoot}/vendor/acquia/drupal-recommended-settings/settings/acquia-recommended.settings.php";
+//    $this->assertNotEmpty($settings);
+//    $this->assertArrayHasKey('config_sync_directory', $settings);
+//    $this->assertArrayHasKey('site_studio_sync', $settings);
+//    $this->assertArrayHasKey('file_public_path', $settings);
+//    $this->assertArrayHasKey('hash_salt', $settings);
+//    $this->assertArrayHasKey('file_private_path', $settings);
+//    $this->assertSame("../config/$site_path", $settings['config_sync_directory']);
+//    $this->assertSame("../sitestudio/$site_path", $settings['site_studio_sync']);
+//    $this->assertSame("sites/$site_path/files", $settings['file_public_path']);
+//    $this->assertSame($this->projectRoot . "/files-private/$site_path", $settings['file_private_path']);
+//    $this->assertNotEmpty($settings['hash_salt']);
   }
 
   /**

--- a/tests/src/Mock/Drupal.php
+++ b/tests/src/Mock/Drupal.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Acquia\Drupal\RecommendedSettings\Tests\Mock;
+
+/**
+ * A mock class to provide a Drupal core version for testing purpose.
+ */
+class Drupal {
+
+  /**
+   * The current system version.
+   */
+  const VERSION = '11.x';
+
+}


### PR DESCRIPTION
**Motivation**
Update the private files directory path for CI environment.
The current path for private files is `<repo_root>/docroot/files-private` and it's changed to `<repo_root>/files-private/<site_name>`. This change aligns with Drupal best practices by keeping private files outside of the `docroot` and supports multisite configurations.

**Proposed changes**
Updated the path in `ci.settings.php`.

**Alternatives considered**
N/A.

**Testing steps**
CI Should pass.
